### PR TITLE
Reorganize routes to implement protected routes with Expo Router

### DIFF
--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -2,8 +2,8 @@ from datetime import timedelta
 from typing import Annotated, Any
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
 
 from app import crud
@@ -23,15 +23,18 @@ router = APIRouter(tags=["login"])
 
 
 @router.get("/login/google")
-async def login_google():
+async def login_google(request: Request):
     """
     Redirect users to Google for authentication
     """
+    # Check if request is from mobile app
+    is_mobile = request.headers.get("User-Agent", "").lower().find("expo") != -1
+    
     params = {
         "client_id": settings.GOOGLE_CLIENT_ID,
         "response_type": "code",
         "scope": "openid email profile",
-        "redirect_uri": settings.GOOGLE_REDIRECT_URI,
+        "redirect_uri": settings.GOOGLE_MOBILE_REDIRECT_URI if is_mobile else settings.GOOGLE_REDIRECT_URI,
         "prompt": "select_account",
     }
 
@@ -46,62 +49,178 @@ async def auth_google(session: SessionDep, code: str):
     """
     Handle Google OAuth2 callback and issue a JWT token.
     """
-    token_data = {
-        "code": code,
-        "client_id": settings.GOOGLE_CLIENT_ID,
-        "client_secret": settings.GOOGLE_CLIENT_SECRET,
-        "redirect_uri": settings.GOOGLE_REDIRECT_URI,
-        "grant_type": "authorization_code",
-    }
+    try:
+        token_data = {
+            "code": code,
+            "client_id": settings.GOOGLE_CLIENT_ID,
+            "client_secret": settings.GOOGLE_CLIENT_SECRET,
+            "redirect_uri": settings.GOOGLE_REDIRECT_URI,
+            "grant_type": "authorization_code",
+        }
 
-    async with httpx.AsyncClient() as client:
-        # Exchange authorization code for access token
-        token_response = await client.post(settings.GOOGLE_TOKEN_URL, data=token_data)
-        if token_response.status_code != 200:
-            raise HTTPException(
-                status_code=token_response.status_code,
-                detail="Failed to retrieve access token.",
+        async with httpx.AsyncClient() as client:
+            # Exchange authorization code for access token
+            token_response = await client.post(settings.GOOGLE_TOKEN_URL, data=token_data)
+            if token_response.status_code != 200:
+                raise HTTPException(
+                    status_code=token_response.status_code,
+                    detail=f"Failed to retrieve access token: {token_response.text}",
+                )
+            token_json = token_response.json()
+
+            # Fetch user info from Google
+            userinfo_response = await client.get(
+                settings.GOOGLE_USER_INFO_URL,
+                headers={"Authorization": f"Bearer {token_json['access_token']}"},
             )
-        token_json = token_response.json()
+            if userinfo_response.status_code != 200:
+                raise HTTPException(
+                    status_code=userinfo_response.status_code,
+                    detail=f"Failed to retrieve user info: {userinfo_response.text}",
+                )
+            user_json = userinfo_response.json()
 
-        # Fetch user info from Google
-        userinfo_response = await client.get(
-            settings.GOOGLE_USER_INFO_URL,
-            headers={"Authorization": f"Bearer {token_json['access_token']}"},
+            user_email = user_json.get("email")
+            if not user_email:
+                raise HTTPException(
+                    status_code=400, detail="Email not available in user info."
+                )
+
+            # Check if user exists in database
+            user = crud.get_user_by_email(session=session, email=user_email)
+            if not user:
+                user = User(
+                    email=user_email,
+                    full_name=user_json.get("name", ""),
+                    is_active=True,
+                    google_id=user_json["sub"],
+                )
+                session.add(user)
+                session.commit()
+                session.refresh(user)
+            elif not user.google_id:
+                # Update existing user with Google ID if they didn't have one
+                user.google_id = user_json["sub"]
+                session.add(user)
+                session.commit()
+                session.refresh(user)
+
+            # Generate JWT token
+            access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+            jwt_token = security.create_access_token(
+                subject=user.id, expires_delta=access_token_expires
+            )
+
+            # Set cookie with token for web clients
+            response = RedirectResponse(url=f"{settings.FRONTEND_HOST}")
+            response.set_cookie(
+                key="access_token",
+                value=f"Bearer {jwt_token}",
+                httponly=True,
+                max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+                expires=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+                samesite="lax",
+                secure=settings.ENVIRONMENT != "local",
+            )
+            
+            return response
+    except Exception as e:
+        # Log the error
+        print(f"Google auth error: {str(e)}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Authentication error: {str(e)}",
         )
-        if userinfo_response.status_code != 200:
-            raise HTTPException(
-                status_code=userinfo_response.status_code,
-                detail="Failed to retrieve user info.",
-            )
-        user_json = userinfo_response.json()
 
-        # TODO: properly create a user, add schemas
-        user_email = user_json.get("email")
-        if not user_email:
-            raise HTTPException(
-                status_code=400, detail="Email not available in user info."
+
+@router.get("/login/auth/google/mobile")
+async def auth_google_mobile(session: SessionDep, code: str):
+    """
+    Handle Google OAuth2 callback for mobile apps and return JSON response with token.
+    """
+    try:
+        token_data = {
+            "code": code,
+            "client_id": settings.GOOGLE_CLIENT_ID,
+            "client_secret": settings.GOOGLE_CLIENT_SECRET,
+            "redirect_uri": settings.GOOGLE_MOBILE_REDIRECT_URI,
+            "grant_type": "authorization_code",
+        }
+
+        async with httpx.AsyncClient() as client:
+            # Exchange authorization code for access token
+            token_response = await client.post(settings.GOOGLE_TOKEN_URL, data=token_data)
+            if token_response.status_code != 200:
+                raise HTTPException(
+                    status_code=token_response.status_code,
+                    detail=f"Failed to retrieve access token: {token_response.text}",
+                )
+            token_json = token_response.json()
+
+            # Fetch user info from Google
+            userinfo_response = await client.get(
+                settings.GOOGLE_USER_INFO_URL,
+                headers={"Authorization": f"Bearer {token_json['access_token']}"},
+            )
+            if userinfo_response.status_code != 200:
+                raise HTTPException(
+                    status_code=userinfo_response.status_code,
+                    detail=f"Failed to retrieve user info: {userinfo_response.text}",
+                )
+            user_json = userinfo_response.json()
+
+            user_email = user_json.get("email")
+            if not user_email:
+                raise HTTPException(
+                    status_code=400, detail="Email not available in user info."
+                )
+
+            # Check if user exists in database
+            user = crud.get_user_by_email(session=session, email=user_email)
+            if not user:
+                user = User(
+                    email=user_email,
+                    full_name=user_json.get("name", ""),
+                    is_active=True,
+                    google_id=user_json["sub"],
+                )
+                session.add(user)
+                session.commit()
+                session.refresh(user)
+            elif not user.google_id:
+                # Update existing user with Google ID if they didn't have one
+                user.google_id = user_json["sub"]
+                session.add(user)
+                session.commit()
+                session.refresh(user)
+
+            # Generate JWT token
+            access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+            jwt_token = security.create_access_token(
+                subject=user.id, expires_delta=access_token_expires
             )
 
-        # Check if user exists in database
-        user = crud.get_user_by_email(session=session, email=user_email)
-        if not user:
-            user = User(
-                email=user_email,
-                full_name=user_json.get("name", ""),
-                is_active=True,
-                google_id=user_json["sub"],
-            )
-            session.add(user)
-            session.commit()
-
-        # Generate JWT token
-        access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-        jwt_token = security.create_access_token(
-            subject=user.id, expires_delta=access_token_expires
+            # Return JSON response for mobile clients
+            user_data = {
+                "id": str(user.id),
+                "email": user.email,
+                "full_name": user.full_name,
+                "is_active": user.is_active,
+                "is_superuser": user.is_superuser,
+            }
+            
+            return {
+                "access_token": jwt_token,
+                "token_type": "bearer",
+                "user": user_data
+            }
+    except Exception as e:
+        # Log the error
+        print(f"Google auth mobile error: {str(e)}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Authentication error: {str(e)}",
         )
-
-        return Token(access_token=jwt_token, token_type="bearer")
 
 
 @router.post("/login/access-token")

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -30,6 +30,11 @@ async def login_google(request: Request):
     # Check if request is from mobile app
     is_mobile = request.headers.get("User-Agent", "").lower().find("expo") != -1
     
+    # Get code_challenge and code_challenge_method from query params for PKCE flow
+    code_challenge = request.query_params.get("code_challenge")
+    code_challenge_method = request.query_params.get("code_challenge_method", "S256")
+    
+    # Base parameters for authorization request
     params = {
         "client_id": settings.GOOGLE_CLIENT_ID,
         "response_type": "code",
@@ -37,6 +42,11 @@ async def login_google(request: Request):
         "redirect_uri": settings.GOOGLE_MOBILE_REDIRECT_URI if is_mobile else settings.GOOGLE_REDIRECT_URI,
         "prompt": "select_account",
     }
+    
+    # Add PKCE parameters if provided (for mobile clients)
+    if code_challenge:
+        params["code_challenge"] = code_challenge
+        params["code_challenge_method"] = code_challenge_method
 
     authorize_url = f"{settings.GOOGLE_AUTH_URL}?" + "&".join(
         f"{k}={v}" for k, v in params.items()
@@ -134,18 +144,26 @@ async def auth_google(session: SessionDep, code: str):
 
 
 @router.get("/login/auth/google/mobile")
-async def auth_google_mobile(session: SessionDep, code: str):
+async def auth_google_mobile(session: SessionDep, code: str, code_verifier: str = None):
     """
     Handle Google OAuth2 callback for mobile apps and return JSON response with token.
+    Uses PKCE flow when code_verifier is provided.
     """
     try:
+        # Base token request data
         token_data = {
             "code": code,
             "client_id": settings.GOOGLE_CLIENT_ID,
-            "client_secret": settings.GOOGLE_CLIENT_SECRET,
             "redirect_uri": settings.GOOGLE_MOBILE_REDIRECT_URI,
             "grant_type": "authorization_code",
         }
+        
+        # Add code_verifier for PKCE flow if provided
+        if code_verifier:
+            token_data["code_verifier"] = code_verifier
+        else:
+            # For non-PKCE flow, client secret is required
+            token_data["client_secret"] = settings.GOOGLE_CLIENT_SECRET
 
         async with httpx.AsyncClient() as client:
             # Exchange authorization code for access token

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -52,6 +52,7 @@ class Settings(BaseSettings):
 
     PROJECT_NAME: str
     SENTRY_DSN: HttpUrl | None = None
+
     POSTGRES_SERVER: str
     POSTGRES_PORT: int = 5432
     POSTGRES_USER: str
@@ -96,16 +97,23 @@ class Settings(BaseSettings):
     FIRST_SUPERUSER: EmailStr
     FIRST_SUPERUSER_PASSWORD: str
 
-    GOOGLE_CLIENT_ID: str = ""
-    GOOGLE_CLIENT_SECRET: str = ""
+    # Google OAuth settings
+    # Replace with your actual Google OAuth credentials
+    GOOGLE_CLIENT_ID: str = "YOUR_GOOGLE_CLIENT_ID_HERE"  # <-- Replace with your Google Client ID
+    GOOGLE_CLIENT_SECRET: str = "YOUR_GOOGLE_CLIENT_SECRET_HERE"  # <-- Replace with your Google Client Secret
     GOOGLE_AUTH_URL: str = "https://accounts.google.com/o/oauth2/auth"
     GOOGLE_TOKEN_URL: str = "https://oauth2.googleapis.com/token"
     GOOGLE_USER_INFO_URL: str = "https://www.googleapis.com/oauth2/v3/userinfo"
 
     @property
     def GOOGLE_REDIRECT_URI(self) -> str:
-        # return f"{self.BACKEND_HOST}{self.API_V1_STR}/login/auth/google"
-        return f"http://127.0.0.1:8000{self.API_V1_STR}/login/auth/google"
+        # Use the proper backend host instead of hardcoded value
+        return f"{self.BACKEND_HOST}{self.API_V1_STR}/login/auth/google"
+
+    # Mobile-specific redirect URI for deep linking
+    @property
+    def GOOGLE_MOBILE_REDIRECT_URI(self) -> str:
+        return f"{self.BACKEND_HOST}{self.API_V1_STR}/login/auth/google/mobile"
 
     def _check_default_secret(self, var_name: str, value: str | None) -> None:
         if value == "changethis":

--- a/backend/app/tests/api/routes/test_google_auth.py
+++ b/backend/app/tests/api/routes/test_google_auth.py
@@ -1,0 +1,300 @@
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+import json
+import uuid
+
+# Create a mock for the app and dependencies
+@pytest.fixture
+def mock_app():
+    # Import app after mocking settings
+    with patch('app.core.config.settings') as mock_settings:
+        # Configure mock settings
+        mock_settings.GOOGLE_CLIENT_ID = "test-client-id"
+        mock_settings.GOOGLE_CLIENT_SECRET = "test-client-secret"
+        mock_settings.GOOGLE_REDIRECT_URI = "http://localhost:8000/api/v1/login/auth/google"
+        mock_settings.GOOGLE_MOBILE_REDIRECT_URI = "http://localhost:8000/api/v1/login/auth/google/mobile"
+        mock_settings.GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/auth"
+        mock_settings.GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+        mock_settings.GOOGLE_USER_INFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
+        mock_settings.FRONTEND_HOST = "http://localhost:5173"
+        mock_settings.ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 8
+        mock_settings.ENVIRONMENT = "local"
+        
+        # Import app after mocking settings
+        from app.main import app
+        
+        # Create test client
+        client = TestClient(app)
+        
+        # Override dependencies
+        from app.api.deps import get_current_active_user, get_session
+        
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.id = uuid.uuid4()
+        mock_user.email = "test@example.com"
+        mock_user.full_name = "Test User"
+        mock_user.is_active = True
+        mock_user.is_superuser = False
+        mock_user.google_id = "google123"
+        
+        # Create mock session
+        mock_session = MagicMock()
+        
+        # Override dependencies
+        app.dependency_overrides[get_current_active_user] = lambda: mock_user
+        app.dependency_overrides[get_session] = lambda: mock_session
+        
+        yield client, mock_session, mock_user
+
+class TestGoogleAuth:
+    
+    def test_login_google_web(self, mock_app):
+        client, _, _ = mock_app
+        
+        # Test the endpoint
+        response = client.get("/api/v1/login/google")
+        
+        # Check that we get a redirect
+        assert response.status_code == 307
+        
+        # Check that the redirect URL contains the expected parameters
+        redirect_url = response.headers["location"]
+        assert "accounts.google.com/o/oauth2/auth" in redirect_url
+        assert "client_id=test-client-id" in redirect_url
+        assert "response_type=code" in redirect_url
+        assert "scope=openid+email+profile" in redirect_url
+        assert "redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fv1%2Flogin%2Fauth%2Fgoogle" in redirect_url
+    
+    def test_login_google_mobile(self, mock_app):
+        client, _, _ = mock_app
+        
+        # Test the endpoint with a mobile user agent
+        response = client.get(
+            "/api/v1/login/google", 
+            headers={"User-Agent": "Expo/1.0"}
+        )
+        
+        # Check that we get a redirect
+        assert response.status_code == 307
+        
+        # Check that the redirect URL contains the expected parameters
+        redirect_url = response.headers["location"]
+        assert "accounts.google.com/o/oauth2/auth" in redirect_url
+        assert "client_id=test-client-id" in redirect_url
+        assert "response_type=code" in redirect_url
+        assert "scope=openid+email+profile" in redirect_url
+        assert "redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fv1%2Flogin%2Fauth%2Fgoogle%2Fmobile" in redirect_url
+    
+    @patch('httpx.AsyncClient')
+    def test_auth_google_success(self, mock_client, mock_app):
+        client, mock_session, mock_user = mock_app
+        
+        # Mock the httpx client
+        mock_async_client = AsyncMock()
+        mock_client.return_value.__aenter__.return_value = mock_async_client
+        
+        # Mock the token response
+        mock_token_response = MagicMock()
+        mock_token_response.status_code = 200
+        mock_token_response.json.return_value = {
+            "access_token": "test-access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600
+        }
+        mock_async_client.post.return_value = mock_token_response
+        
+        # Mock the userinfo response
+        mock_userinfo_response = MagicMock()
+        mock_userinfo_response.status_code = 200
+        mock_userinfo_response.json.return_value = {
+            "sub": "google123",
+            "email": "test@example.com",
+            "name": "Test User",
+            "picture": "https://example.com/picture.jpg"
+        }
+        mock_async_client.get.return_value = mock_userinfo_response
+        
+        # Mock the crud.get_user_by_email function
+        with patch('app.crud.get_user_by_email') as mock_get_user:
+            mock_get_user.return_value = mock_user
+            
+            # Mock the security.create_access_token function
+            with patch('app.core.security.create_access_token') as mock_create_token:
+                mock_create_token.return_value = "test-jwt-token"
+                
+                # Test the endpoint
+                response = client.get("/api/v1/login/auth/google?code=test-code")
+                
+                # Check that we get a redirect
+                assert response.status_code == 307
+                
+                # Check that the redirect URL is the frontend host
+                assert response.headers["location"] == "http://localhost:5173"
+                
+                # Check that we set a cookie with the token
+                assert "access_token" in response.cookies
+                assert response.cookies["access_token"] == "Bearer test-jwt-token"
+    
+    @patch('httpx.AsyncClient')
+    def test_auth_google_mobile_success(self, mock_client, mock_app):
+        client, mock_session, mock_user = mock_app
+        
+        # Mock the httpx client
+        mock_async_client = AsyncMock()
+        mock_client.return_value.__aenter__.return_value = mock_async_client
+        
+        # Mock the token response
+        mock_token_response = MagicMock()
+        mock_token_response.status_code = 200
+        mock_token_response.json.return_value = {
+            "access_token": "test-access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600
+        }
+        mock_async_client.post.return_value = mock_token_response
+        
+        # Mock the userinfo response
+        mock_userinfo_response = MagicMock()
+        mock_userinfo_response.status_code = 200
+        mock_userinfo_response.json.return_value = {
+            "sub": "google123",
+            "email": "test@example.com",
+            "name": "Test User",
+            "picture": "https://example.com/picture.jpg"
+        }
+        mock_async_client.get.return_value = mock_userinfo_response
+        
+        # Mock the crud.get_user_by_email function
+        with patch('app.crud.get_user_by_email') as mock_get_user:
+            mock_get_user.return_value = mock_user
+            
+            # Mock the security.create_access_token function
+            with patch('app.core.security.create_access_token') as mock_create_token:
+                mock_create_token.return_value = "test-jwt-token"
+                
+                # Test the endpoint
+                response = client.get("/api/v1/login/auth/google/mobile?code=test-code")
+                
+                # Check that we get a successful response
+                assert response.status_code == 200
+                
+                # Check the response JSON
+                response_json = response.json()
+                assert response_json["access_token"] == "test-jwt-token"
+                assert response_json["token_type"] == "bearer"
+                assert response_json["user"]["email"] == "test@example.com"
+                assert response_json["user"]["full_name"] == "Test User"
+    
+    @patch('httpx.AsyncClient')
+    def test_auth_google_token_error(self, mock_client, mock_app):
+        client, _, _ = mock_app
+        
+        # Mock the httpx client
+        mock_async_client = AsyncMock()
+        mock_client.return_value.__aenter__.return_value = mock_async_client
+        
+        # Mock the token response with an error
+        mock_token_response = MagicMock()
+        mock_token_response.status_code = 400
+        mock_token_response.text = "Invalid grant"
+        mock_async_client.post.return_value = mock_token_response
+        
+        # Test the endpoint
+        response = client.get("/api/v1/login/auth/google?code=invalid-code")
+        
+        # Check that we get an error
+        assert response.status_code == 400
+        assert "Failed to retrieve access token" in response.json()["detail"]
+    
+    @patch('httpx.AsyncClient')
+    def test_auth_google_userinfo_error(self, mock_client, mock_app):
+        client, _, _ = mock_app
+        
+        # Mock the httpx client
+        mock_async_client = AsyncMock()
+        mock_client.return_value.__aenter__.return_value = mock_async_client
+        
+        # Mock the token response
+        mock_token_response = MagicMock()
+        mock_token_response.status_code = 200
+        mock_token_response.json.return_value = {
+            "access_token": "test-access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600
+        }
+        mock_async_client.post.return_value = mock_token_response
+        
+        # Mock the userinfo response with an error
+        mock_userinfo_response = MagicMock()
+        mock_userinfo_response.status_code = 401
+        mock_userinfo_response.text = "Invalid token"
+        mock_async_client.get.return_value = mock_userinfo_response
+        
+        # Test the endpoint
+        response = client.get("/api/v1/login/auth/google?code=test-code")
+        
+        # Check that we get an error
+        assert response.status_code == 401
+        assert "Failed to retrieve user info" in response.json()["detail"]
+    
+    @patch('httpx.AsyncClient')
+    def test_auth_google_create_new_user(self, mock_client, mock_app):
+        client, mock_session, _ = mock_app
+        
+        # Mock the httpx client
+        mock_async_client = AsyncMock()
+        mock_client.return_value.__aenter__.return_value = mock_async_client
+        
+        # Mock the token response
+        mock_token_response = MagicMock()
+        mock_token_response.status_code = 200
+        mock_token_response.json.return_value = {
+            "access_token": "test-access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600
+        }
+        mock_async_client.post.return_value = mock_token_response
+        
+        # Mock the userinfo response
+        mock_userinfo_response = MagicMock()
+        mock_userinfo_response.status_code = 200
+        mock_userinfo_response.json.return_value = {
+            "sub": "google456",
+            "email": "newuser@example.com",
+            "name": "New User",
+            "picture": "https://example.com/picture.jpg"
+        }
+        mock_async_client.get.return_value = mock_userinfo_response
+        
+        # Mock the crud.get_user_by_email function to return None (user doesn't exist)
+        with patch('app.crud.get_user_by_email') as mock_get_user:
+            mock_get_user.return_value = None
+            
+            # Mock the User model
+            with patch('app.models.User') as mock_user_model:
+                mock_new_user = MagicMock()
+                mock_new_user.id = uuid.uuid4()
+                mock_new_user.email = "newuser@example.com"
+                mock_new_user.full_name = "New User"
+                mock_new_user.is_active = True
+                mock_new_user.google_id = "google456"
+                mock_user_model.return_value = mock_new_user
+                
+                # Mock the security.create_access_token function
+                with patch('app.core.security.create_access_token') as mock_create_token:
+                    mock_create_token.return_value = "test-jwt-token"
+                    
+                    # Test the endpoint
+                    response = client.get("/api/v1/login/auth/google?code=test-code")
+                    
+                    # Check that we get a redirect
+                    assert response.status_code == 307
+                    
+                    # Check that the user was added to the session
+                    mock_session.add.assert_called_once_with(mock_new_user)
+                    mock_session.commit.assert_called_once()
+                    mock_session.refresh.assert_called_once_with(mock_new_user)

--- a/frontend-rn/app/(app)/(tabs)/_layout.tsx
+++ b/frontend-rn/app/(app)/(tabs)/_layout.tsx
@@ -1,0 +1,45 @@
+import { Tabs } from 'expo-router';
+import React from 'react';
+import { Platform } from 'react-native';
+
+import { HapticTab } from '@/components/HapticTab';
+import { IconSymbol } from '@/components/ui/IconSymbol';
+import TabBarBackground from '@/components/ui/TabBarBackground';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+export default function TabLayout() {
+  const colorScheme = useColorScheme();
+
+  return (
+    <Tabs
+      screenOptions={{
+        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+        headerShown: false,
+        tabBarButton: HapticTab,
+        tabBarBackground: TabBarBackground,
+        tabBarStyle: Platform.select({
+          ios: {
+            // Use a transparent background on iOS to show the blur effect
+            position: 'absolute',
+          },
+          default: {},
+        }),
+      }}>
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: 'Home',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="explore"
+        options={{
+          title: 'Explore',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/frontend-rn/app/(app)/(tabs)/explore.tsx
+++ b/frontend-rn/app/(app)/(tabs)/explore.tsx
@@ -1,0 +1,109 @@
+import { StyleSheet, Image, Platform } from 'react-native';
+
+import { Collapsible } from '@/components/Collapsible';
+import { ExternalLink } from '@/components/ExternalLink';
+import ParallaxScrollView from '@/components/ParallaxScrollView';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { IconSymbol } from '@/components/ui/IconSymbol';
+
+export default function TabTwoScreen() {
+  return (
+    <ParallaxScrollView
+      headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
+      headerImage={
+        <IconSymbol
+          size={310}
+          color="#808080"
+          name="chevron.left.forwardslash.chevron.right"
+          style={styles.headerImage}
+        />
+      }>
+      <ThemedView style={styles.titleContainer}>
+        <ThemedText type="title">Explore</ThemedText>
+      </ThemedView>
+      <ThemedText>This app includes example code to help you get started.</ThemedText>
+      <Collapsible title="File-based routing">
+        <ThemedText>
+          This app has two screens:{' '}
+          <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> and{' '}
+          <ThemedText type="defaultSemiBold">app/(tabs)/explore.tsx</ThemedText>
+        </ThemedText>
+        <ThemedText>
+          The layout file in <ThemedText type="defaultSemiBold">app/(tabs)/_layout.tsx</ThemedText>{' '}
+          sets up the tab navigator.
+        </ThemedText>
+        <ExternalLink href="https://docs.expo.dev/router/introduction">
+          <ThemedText type="link">Learn more</ThemedText>
+        </ExternalLink>
+      </Collapsible>
+      <Collapsible title="Android, iOS, and web support">
+        <ThemedText>
+          You can open this project on Android, iOS, and the web. To open the web version, press{' '}
+          <ThemedText type="defaultSemiBold">w</ThemedText> in the terminal running this project.
+        </ThemedText>
+      </Collapsible>
+      <Collapsible title="Images">
+        <ThemedText>
+          For static images, you can use the <ThemedText type="defaultSemiBold">@2x</ThemedText> and{' '}
+          <ThemedText type="defaultSemiBold">@3x</ThemedText> suffixes to provide files for
+          different screen densities
+        </ThemedText>
+        <Image source={require('@/assets/images/react-logo.png')} style={{ alignSelf: 'center' }} />
+        <ExternalLink href="https://reactnative.dev/docs/images">
+          <ThemedText type="link">Learn more</ThemedText>
+        </ExternalLink>
+      </Collapsible>
+      <Collapsible title="Custom fonts">
+        <ThemedText>
+          Open <ThemedText type="defaultSemiBold">app/_layout.tsx</ThemedText> to see how to load{' '}
+          <ThemedText style={{ fontFamily: 'SpaceMono' }}>
+            custom fonts such as this one.
+          </ThemedText>
+        </ThemedText>
+        <ExternalLink href="https://docs.expo.dev/versions/latest/sdk/font">
+          <ThemedText type="link">Learn more</ThemedText>
+        </ExternalLink>
+      </Collapsible>
+      <Collapsible title="Light and dark mode components">
+        <ThemedText>
+          This template has light and dark mode support. The{' '}
+          <ThemedText type="defaultSemiBold">useColorScheme()</ThemedText> hook lets you inspect
+          what the user's current color scheme is, and so you can adjust UI colors accordingly.
+        </ThemedText>
+        <ExternalLink href="https://docs.expo.dev/develop/user-interface/color-themes/">
+          <ThemedText type="link">Learn more</ThemedText>
+        </ExternalLink>
+      </Collapsible>
+      <Collapsible title="Animations">
+        <ThemedText>
+          This template includes an example of an animated component. The{' '}
+          <ThemedText type="defaultSemiBold">components/HelloWave.tsx</ThemedText> component uses
+          the powerful <ThemedText type="defaultSemiBold">react-native-reanimated</ThemedText>{' '}
+          library to create a waving hand animation.
+        </ThemedText>
+        {Platform.select({
+          ios: (
+            <ThemedText>
+              The <ThemedText type="defaultSemiBold">components/ParallaxScrollView.tsx</ThemedText>{' '}
+              component provides a parallax effect for the header image.
+            </ThemedText>
+          ),
+        })}
+      </Collapsible>
+    </ParallaxScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerImage: {
+    color: '#808080',
+    bottom: -90,
+    left: -35,
+    position: 'absolute',
+  },
+  titleContainer: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+});

--- a/frontend-rn/app/(app)/(tabs)/health-check.tsx
+++ b/frontend-rn/app/(app)/(tabs)/health-check.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
+import { OpenAPI, UtilsService } from '@/src/client';
+
+export default function HealthCheckScreen() {
+  const fullUrl = `${OpenAPI.BASE}/api/v1/utils/health-check/`;
+  console.log("Calling health check at:", fullUrl);
+
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['health-check'],
+    queryFn: () => UtilsService.healthCheck(),
+    staleTime: 0,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+    refetchInterval: 30000
+  });
+
+  return (
+    <View style={styles.container}>
+      {isLoading ? <ActivityIndicator size="small" color="#0000ff" /> :
+      <Text style={error ? styles.errorText : styles.statusText}>
+        {error ? `Error: ${error instanceof Error ? error.message : 'Unknown'}` : `Status: ${data ? 'Healthy ✓' : 'Unhealthy ✗'}`}
+      </Text>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  statusText: { color: '#22c55e', fontWeight: 'bold' },
+  errorText: { color: '#ef4444', fontWeight: 'bold' },
+});

--- a/frontend-rn/app/(app)/(tabs)/index.tsx
+++ b/frontend-rn/app/(app)/(tabs)/index.tsx
@@ -1,0 +1,74 @@
+import { Image, StyleSheet, Platform } from 'react-native';
+
+import { HelloWave } from '@/components/HelloWave';
+import ParallaxScrollView from '@/components/ParallaxScrollView';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function HomeScreen() {
+  return (
+    <ParallaxScrollView
+      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
+      headerImage={
+        <Image
+          source={require('@/assets/images/partial-react-logo.png')}
+          style={styles.reactLogo}
+        />
+      }>
+      <ThemedView style={styles.titleContainer}>
+        <ThemedText type="title">Welcome!</ThemedText>
+        <HelloWave />
+      </ThemedView>
+      <ThemedView style={styles.stepContainer}>
+        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
+        <ThemedText>
+          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
+          Press{' '}
+          <ThemedText type="defaultSemiBold">
+            {Platform.select({
+              ios: 'cmd + d',
+              android: 'cmd + m',
+              web: 'F12'
+            })}
+          </ThemedText>{' '}
+          to open developer tools.
+        </ThemedText>
+      </ThemedView>
+      <ThemedView style={styles.stepContainer}>
+        <ThemedText type="subtitle">Step 2: Explore</ThemedText>
+        <ThemedText>
+          Tap the Explore tab to learn more about what's included in this starter app.
+        </ThemedText>
+      </ThemedView>
+      <ThemedView style={styles.stepContainer}>
+        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
+        <ThemedText>
+          When you're ready, run{' '}
+          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
+          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
+          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
+          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
+        </ThemedText>
+      </ThemedView>
+    </ParallaxScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  titleContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  stepContainer: {
+    gap: 8,
+    marginBottom: 8,
+  },
+  reactLogo: {
+    height: 178,
+    width: 290,
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+  },
+});

--- a/frontend-rn/app/(app)/(tabs)/profile.tsx
+++ b/frontend-rn/app/(app)/(tabs)/profile.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
+import { useAuth } from '@/hooks/useAuth';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function ProfileScreen() {
+  const { user, logout } = useAuth();
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } catch (error) {
+      console.error('Logout error:', error);
+    }
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText style={styles.title}>Profile</ThemedText>
+      
+      {user ? (
+        <View style={styles.profileContainer}>
+          <ThemedText style={styles.label}>Email:</ThemedText>
+          <ThemedText style={styles.value}>{user.email}</ThemedText>
+          
+          <ThemedText style={styles.label}>Name:</ThemedText>
+          <ThemedText style={styles.value}>{user.full_name || 'Not provided'}</ThemedText>
+          
+          <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
+            <Text style={styles.logoutButtonText}>Logout</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <ThemedText>Not logged in</ThemedText>
+      )}
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+  },
+  profileContainer: {
+    backgroundColor: 'rgba(0, 0, 0, 0.05)',
+    borderRadius: 8,
+    padding: 16,
+    marginBottom: 20,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  value: {
+    fontSize: 16,
+    marginBottom: 16,
+  },
+  logoutButton: {
+    backgroundColor: '#f44336',
+    borderRadius: 4,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  logoutButtonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/frontend-rn/app/(app)/_layout.tsx
+++ b/frontend-rn/app/(app)/_layout.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Stack } from 'expo-router';
+import { AuthGuard } from '@/components/AuthGuard';
+
+export default function AppLayout() {
+  return (
+    <AuthGuard>
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="(tabs)" />
+      </Stack>
+    </AuthGuard>
+  );
+}

--- a/frontend-rn/app/(auth)/_layout.tsx
+++ b/frontend-rn/app/(auth)/_layout.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Stack } from 'expo-router';
+
+export default function AuthLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="sign-in" />
+    </Stack>
+  );
+}

--- a/frontend-rn/app/(auth)/sign-in.tsx
+++ b/frontend-rn/app/(auth)/sign-in.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { StyleSheet, View, Text, TouchableOpacity, Image, ActivityIndicator } from 'react-native';
+import { useGoogleAuth } from '@/hooks/useGoogleAuth';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import { useRouter } from 'expo-router';
+
+export default function LoginScreen() {
+  const { googleSignIn } = useGoogleAuth();
+  const router = useRouter();
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const handleGoogleSignIn = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const success = await googleSignIn();
+      if (success) {
+        // Navigate to home screen on successful login
+        router.replace('/');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred during sign in');
+      console.error('Google sign in error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <View style={styles.logoContainer}>
+        <Image 
+          source={require('../assets/images/icon.png')} 
+          style={styles.logo}
+          resizeMode="contain"
+        />
+      </View>
+      
+      <ThemedText style={styles.title}>Welcome</ThemedText>
+      <ThemedText style={styles.subtitle}>Sign in to continue</ThemedText>
+      
+      {error && (
+        <View style={styles.errorContainer}>
+          <ThemedText style={styles.errorText}>{error}</ThemedText>
+        </View>
+      )}
+      
+      <TouchableOpacity 
+        style={styles.googleButton}
+        onPress={handleGoogleSignIn}
+        disabled={loading}
+      >
+        {loading ? (
+          <ActivityIndicator color="#fff" size="small" />
+        ) : (
+          <>
+            <Image 
+              source={require('../assets/images/google-logo.png')} 
+              style={styles.googleIcon}
+            />
+            <Text style={styles.buttonText}>Sign in with Google</Text>
+          </>
+        )}
+      </TouchableOpacity>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  logoContainer: {
+    marginBottom: 40,
+  },
+  logo: {
+    width: 120,
+    height: 120,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    marginBottom: 10,
+  },
+  subtitle: {
+    fontSize: 16,
+    marginBottom: 30,
+    opacity: 0.7,
+  },
+  googleButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#4285F4',
+    borderRadius: 4,
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    width: '100%',
+    maxWidth: 300,
+  },
+  googleIcon: {
+    width: 24,
+    height: 24,
+    marginRight: 12,
+    backgroundColor: 'white',
+    borderRadius: 12,
+    padding: 2,
+  },
+  buttonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  errorContainer: {
+    marginBottom: 20,
+    padding: 10,
+    backgroundColor: 'rgba(255, 0, 0, 0.1)',
+    borderRadius: 4,
+    width: '100%',
+    maxWidth: 300,
+  },
+  errorText: {
+    color: 'red',
+    textAlign: 'center',
+  },
+});

--- a/frontend-rn/app/(tabs)/profile.tsx
+++ b/frontend-rn/app/(tabs)/profile.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
+import { useAuth } from '@/hooks/useAuth';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function ProfileScreen() {
+  const { user, logout } = useAuth();
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } catch (error) {
+      console.error('Logout error:', error);
+    }
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText style={styles.title}>Profile</ThemedText>
+      
+      {user ? (
+        <View style={styles.profileContainer}>
+          <ThemedText style={styles.label}>Email:</ThemedText>
+          <ThemedText style={styles.value}>{user.email}</ThemedText>
+          
+          <ThemedText style={styles.label}>Name:</ThemedText>
+          <ThemedText style={styles.value}>{user.full_name || 'Not provided'}</ThemedText>
+          
+          <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
+            <Text style={styles.logoutButtonText}>Logout</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <ThemedText>Not logged in</ThemedText>
+      )}
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+  },
+  profileContainer: {
+    backgroundColor: 'rgba(0, 0, 0, 0.05)',
+    borderRadius: 8,
+    padding: 16,
+    marginBottom: 20,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  value: {
+    fontSize: 16,
+    marginBottom: 16,
+  },
+  logoutButton: {
+    backgroundColor: '#f44336',
+    borderRadius: 4,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  logoutButtonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/frontend-rn/app/_layout.tsx
+++ b/frontend-rn/app/_layout.tsx
@@ -11,6 +11,8 @@ import { OpenAPI } from '@/src/client';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useReactQueryDevTools } from '@dev-plugins/react-query';
+import { AuthProvider } from '@/hooks/useAuth';
+import { AuthGuard } from '@/components/AuthGuard';
 
 
 OpenAPI.BASE = Constants.expoConfig?.extra?.API_URL || 'http://localhost:8000';
@@ -20,7 +22,7 @@ const queryClient = new QueryClient();
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
-  useReactQueryDevTools(queryClient);  // TODO: this is only used for debugging, delte this in prod.
+  useReactQueryDevTools(queryClient);  // TODO: this is only used for debugging, delete this in prod.
 
   const colorScheme = useColorScheme();
   const [loaded] = useFonts({
@@ -38,14 +40,19 @@ export default function RootLayout() {
   }
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-        <StatusBar style="auto" />
-      </ThemeProvider>
-    </QueryClientProvider>
+    <AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <AuthGuard>
+            <Stack>
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+              <Stack.Screen name="login" options={{ headerShown: false }} />
+              <Stack.Screen name="+not-found" />
+            </Stack>
+          </AuthGuard>
+          <StatusBar style="auto" />
+        </ThemeProvider>
+      </QueryClientProvider>
+    </AuthProvider>
   );
 }

--- a/frontend-rn/app/_layout.tsx
+++ b/frontend-rn/app/_layout.tsx
@@ -12,8 +12,6 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useReactQueryDevTools } from '@dev-plugins/react-query';
 import { AuthProvider } from '@/hooks/useAuth';
-import { AuthGuard } from '@/components/AuthGuard';
-
 
 OpenAPI.BASE = Constants.expoConfig?.extra?.API_URL || 'http://localhost:8000';
 const queryClient = new QueryClient();
@@ -43,13 +41,11 @@ export default function RootLayout() {
     <AuthProvider>
       <QueryClientProvider client={queryClient}>
         <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-          <AuthGuard>
-            <Stack>
-              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-              <Stack.Screen name="login" options={{ headerShown: false }} />
-              <Stack.Screen name="+not-found" />
-            </Stack>
-          </AuthGuard>
+          <Stack screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="(auth)" />
+            <Stack.Screen name="(app)" />
+            <Stack.Screen name="+not-found" options={{ headerShown: true }} />
+          </Stack>
           <StatusBar style="auto" />
         </ThemeProvider>
       </QueryClientProvider>

--- a/frontend-rn/app/login.tsx
+++ b/frontend-rn/app/login.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { StyleSheet, View, Text, TouchableOpacity, Image, ActivityIndicator } from 'react-native';
+import { useGoogleAuth } from '@/hooks/useGoogleAuth';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import { useRouter } from 'expo-router';
+
+export default function LoginScreen() {
+  const { googleSignIn } = useGoogleAuth();
+  const router = useRouter();
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const handleGoogleSignIn = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const success = await googleSignIn();
+      if (success) {
+        // Navigate to home screen on successful login
+        router.replace('/');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred during sign in');
+      console.error('Google sign in error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <View style={styles.logoContainer}>
+        <Image 
+          source={require('../assets/images/icon.png')} 
+          style={styles.logo}
+          resizeMode="contain"
+        />
+      </View>
+      
+      <ThemedText style={styles.title}>Welcome</ThemedText>
+      <ThemedText style={styles.subtitle}>Sign in to continue</ThemedText>
+      
+      {error && (
+        <View style={styles.errorContainer}>
+          <ThemedText style={styles.errorText}>{error}</ThemedText>
+        </View>
+      )}
+      
+      <TouchableOpacity 
+        style={styles.googleButton}
+        onPress={handleGoogleSignIn}
+        disabled={loading}
+      >
+        {loading ? (
+          <ActivityIndicator color="#fff" size="small" />
+        ) : (
+          <>
+            <Image 
+              source={require('../assets/images/google-logo.png')} 
+              style={styles.googleIcon}
+            />
+            <Text style={styles.buttonText}>Sign in with Google</Text>
+          </>
+        )}
+      </TouchableOpacity>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  logoContainer: {
+    marginBottom: 40,
+  },
+  logo: {
+    width: 120,
+    height: 120,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    marginBottom: 10,
+  },
+  subtitle: {
+    fontSize: 16,
+    marginBottom: 30,
+    opacity: 0.7,
+  },
+  googleButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#4285F4',
+    borderRadius: 4,
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    width: '100%',
+    maxWidth: 300,
+  },
+  googleIcon: {
+    width: 24,
+    height: 24,
+    marginRight: 12,
+    backgroundColor: 'white',
+    borderRadius: 12,
+    padding: 2,
+  },
+  buttonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  errorContainer: {
+    marginBottom: 20,
+    padding: 10,
+    backgroundColor: 'rgba(255, 0, 0, 0.1)',
+    borderRadius: 4,
+    width: '100%',
+    maxWidth: 300,
+  },
+  errorText: {
+    color: 'red',
+    textAlign: 'center',
+  },
+});

--- a/frontend-rn/components/AuthGuard.tsx
+++ b/frontend-rn/components/AuthGuard.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import { Redirect, usePathname } from 'expo-router';
+
+// List of routes that don't require authentication
+const publicRoutes = ['/login'];
+
+export function AuthGuard({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, isLoading } = useAuth();
+  const pathname = usePathname();
+
+  // Don't render anything while checking authentication status
+  if (isLoading) {
+    return null;
+  }
+
+  // If the user is not authenticated and trying to access a protected route,
+  // redirect to the login page
+  if (!isAuthenticated && !publicRoutes.includes(pathname)) {
+    return <Redirect href="/login" />;
+  }
+
+  // If the user is authenticated and trying to access the login page,
+  // redirect to the home page
+  if (isAuthenticated && pathname === '/login') {
+    return <Redirect href="/" />;
+  }
+
+  // Otherwise, render the children
+  return <>{children}</>;
+}

--- a/frontend-rn/components/AuthGuard.tsx
+++ b/frontend-rn/components/AuthGuard.tsx
@@ -1,29 +1,18 @@
 import React from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { Redirect, usePathname } from 'expo-router';
-
-// List of routes that don't require authentication
-const publicRoutes = ['/login'];
+import { Redirect } from 'expo-router';
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth();
-  const pathname = usePathname();
 
   // Don't render anything while checking authentication status
   if (isLoading) {
     return null;
   }
 
-  // If the user is not authenticated and trying to access a protected route,
-  // redirect to the login page
-  if (!isAuthenticated && !publicRoutes.includes(pathname)) {
-    return <Redirect href="/login" />;
-  }
-
-  // If the user is authenticated and trying to access the login page,
-  // redirect to the home page
-  if (isAuthenticated && pathname === '/login') {
-    return <Redirect href="/" />;
+  // If the user is not authenticated, redirect to the sign-in page
+  if (!isAuthenticated) {
+    return <Redirect href="/(auth)/sign-in" />;
   }
 
   // Otherwise, render the children

--- a/frontend-rn/hooks/useAuth.tsx
+++ b/frontend-rn/hooks/useAuth.tsx
@@ -1,0 +1,134 @@
+import React, { createContext, useState, useEffect, useContext, ReactNode } from 'react';
+import * as SecureStore from 'expo-secure-store';
+import { LoginService } from '@/src/client';
+
+// Define the User type
+interface User {
+  id: string;
+  email: string;
+  full_name: string | null;
+  is_active: boolean;
+  is_superuser: boolean;
+}
+
+// Define the context type
+interface AuthContextType {
+  user: User | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (token: string, userData: User) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+// Create the context with a default undefined value
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+// Token storage keys
+const TOKEN_KEY = 'auth_token';
+const USER_KEY = 'auth_user';
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load token and user data from secure storage on mount
+  useEffect(() => {
+    const loadAuthState = async () => {
+      try {
+        const storedToken = await SecureStore.getItemAsync(TOKEN_KEY);
+        const storedUser = await SecureStore.getItemAsync(USER_KEY);
+        
+        if (storedToken && storedUser) {
+          setToken(storedToken);
+          setUser(JSON.parse(storedUser));
+        }
+      } catch (error) {
+        console.error('Error loading auth state:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadAuthState();
+  }, []);
+
+  // Login function
+  const login = async (newToken: string, userData: User) => {
+    try {
+      // Store token and user data in secure storage
+      await SecureStore.setItemAsync(TOKEN_KEY, newToken);
+      await SecureStore.setItemAsync(USER_KEY, JSON.stringify(userData));
+      
+      // Update state
+      setToken(newToken);
+      setUser(userData);
+    } catch (error) {
+      console.error('Error during login:', error);
+      throw error;
+    }
+  };
+
+  // Logout function
+  const logout = async () => {
+    try {
+      // Remove token and user data from secure storage
+      await SecureStore.deleteItemAsync(TOKEN_KEY);
+      await SecureStore.deleteItemAsync(USER_KEY);
+      
+      // Update state
+      setToken(null);
+      setUser(null);
+    } catch (error) {
+      console.error('Error during logout:', error);
+      throw error;
+    }
+  };
+
+  // Test token validity
+  const testToken = async () => {
+    if (!token) return;
+    
+    try {
+      // Call the test-token endpoint to verify token validity
+      await LoginService.testToken();
+    } catch (error) {
+      console.error('Token validation failed:', error);
+      // If token is invalid, log out
+      await logout();
+    }
+  };
+
+  // Test token validity on mount and when token changes
+  useEffect(() => {
+    if (token) {
+      testToken();
+    }
+  }, [token]);
+
+  // Provide the auth context value
+  const value = {
+    user,
+    token,
+    isAuthenticated: !!token,
+    isLoading,
+    login,
+    logout,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+// Custom hook to use the auth context
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/frontend-rn/hooks/useGoogleAuth.tsx
+++ b/frontend-rn/hooks/useGoogleAuth.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import * as WebBrowser from 'expo-web-browser';
+import * as AuthSession from 'expo-auth-session';
+import { Platform } from 'react-native';
+import Constants from 'expo-constants';
+import { useAuth } from './useAuth';
+import { OpenAPI } from '@/src/client';
+
+// Register for the authentication callback
+WebBrowser.maybeCompleteAuthSession();
+
+// Define the response type for Google authentication
+type GoogleAuthResponse = {
+  type: 'success' | 'error';
+  params: {
+    code?: string;
+    error?: string;
+  };
+  url: string;
+};
+
+// Define the user data type returned from the backend
+type UserData = {
+  id: string;
+  email: string;
+  full_name: string | null;
+  is_active: boolean;
+  is_superuser: boolean;
+};
+
+// Define the authentication response type
+type AuthResponse = {
+  access_token: string;
+  token_type: string;
+  user: UserData;
+};
+
+export const useGoogleAuth = () => {
+  const { login } = useAuth();
+  const apiUrl = OpenAPI.BASE;
+
+  // Function to handle Google sign-in
+  const googleSignIn = async () => {
+    try {
+      // Determine if we're on a mobile device
+      const isMobile = Platform.OS !== 'web';
+      
+      // Construct the redirect URI
+      const redirectUri = AuthSession.makeRedirectUri({
+        scheme: 'aindependent',
+        path: 'auth/google',
+      });
+      
+      // Construct the Google auth URL
+      const authUrl = `${apiUrl}/api/v1/login/google`;
+      
+      // Open the browser for authentication
+      const result = await AuthSession.startAsync({
+        authUrl,
+        returnUrl: redirectUri,
+      }) as GoogleAuthResponse;
+      
+      // Handle the authentication result
+      if (result.type === 'success' && result.params.code) {
+        // Exchange the code for a token
+        const response = await fetch(
+          `${apiUrl}/api/v1/login/auth/google/mobile?code=${result.params.code}`,
+          {
+            method: 'GET',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }
+        );
+        
+        if (!response.ok) {
+          throw new Error(`Authentication failed: ${response.statusText}`);
+        }
+        
+        // Parse the response
+        const authData: AuthResponse = await response.json();
+        
+        // Login with the token and user data
+        await login(authData.access_token, authData.user);
+        
+        return true;
+      } else if (result.type === 'error' || result.params.error) {
+        throw new Error(result.params.error || 'Authentication failed');
+      }
+      
+      return false;
+    } catch (error) {
+      console.error('Google sign-in error:', error);
+      throw error;
+    }
+  };
+  
+  return { googleSignIn };
+};

--- a/frontend-rn/hooks/useGoogleAuth.tsx
+++ b/frontend-rn/hooks/useGoogleAuth.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import * as AuthSession from 'expo-auth-session';
+import * as Crypto from 'expo-crypto';
 import { Platform } from 'react-native';
 import Constants from 'expo-constants';
 import { useAuth } from './useAuth';
@@ -35,6 +36,17 @@ type AuthResponse = {
   user: UserData;
 };
 
+// Generate a random string for code verifier
+const generateCodeVerifier = async (): Promise<string> => {
+  const randomBytes = await Crypto.getRandomBytesAsync(32);
+  return AuthSession.buildCodeVerifier(randomBytes);
+};
+
+// Generate a code challenge from the code verifier
+const generateCodeChallenge = async (codeVerifier: string): Promise<string> => {
+  return AuthSession.buildCodeChallenge(codeVerifier, AuthSession.CodeChallengeMethod.S256);
+};
+
 export const useGoogleAuth = () => {
   const { login } = useAuth();
   const apiUrl = OpenAPI.BASE;
@@ -42,6 +54,10 @@ export const useGoogleAuth = () => {
   // Function to handle Google sign-in
   const googleSignIn = async () => {
     try {
+      // Generate code verifier and challenge for PKCE
+      const codeVerifier = await generateCodeVerifier();
+      const codeChallenge = await generateCodeChallenge(codeVerifier);
+      
       // Determine if we're on a mobile device
       const isMobile = Platform.OS !== 'web';
       
@@ -51,8 +67,12 @@ export const useGoogleAuth = () => {
         path: 'auth/google',
       });
       
-      // Construct the Google auth URL
-      const authUrl = `${apiUrl}/api/v1/login/google`;
+      // Construct the Google auth URL with PKCE parameters
+      const authUrl = `${apiUrl}/api/v1/login/google?code_challenge=${codeChallenge}&code_challenge_method=S256`;
+      
+      console.log('Starting authentication with PKCE flow');
+      console.log('Auth URL:', authUrl);
+      console.log('Redirect URI:', redirectUri);
       
       // Open the browser for authentication
       const result = await AuthSession.startAsync({
@@ -62,9 +82,11 @@ export const useGoogleAuth = () => {
       
       // Handle the authentication result
       if (result.type === 'success' && result.params.code) {
-        // Exchange the code for a token
+        console.log('Authentication successful, exchanging code for token');
+        
+        // Exchange the code for a token using PKCE
         const response = await fetch(
-          `${apiUrl}/api/v1/login/auth/google/mobile?code=${result.params.code}`,
+          `${apiUrl}/api/v1/login/auth/google/mobile?code=${result.params.code}&code_verifier=${codeVerifier}`,
           {
             method: 'GET',
             headers: {
@@ -74,21 +96,26 @@ export const useGoogleAuth = () => {
         );
         
         if (!response.ok) {
+          const errorText = await response.text();
+          console.error('Token exchange failed:', response.status, errorText);
           throw new Error(`Authentication failed: ${response.statusText}`);
         }
         
         // Parse the response
         const authData: AuthResponse = await response.json();
+        console.log('Token exchange successful');
         
         // Login with the token and user data
         await login(authData.access_token, authData.user);
         
         return true;
       } else if (result.type === 'error' || result.params.error) {
+        console.error('Authentication error:', result.params.error);
         throw new Error(result.params.error || 'Authentication failed');
+      } else {
+        console.log('Authentication cancelled or failed');
+        return false;
       }
-      
-      return false;
     } catch (error) {
       console.error('Google sign-in error:', error);
       throw error;

--- a/frontend-rn/tests/auth.test.tsx
+++ b/frontend-rn/tests/auth.test.tsx
@@ -1,0 +1,393 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { useRouter } from 'expo-router';
+import * as AuthSession from 'expo-auth-session';
+import * as SecureStore from 'expo-secure-store';
+import { AuthProvider, useAuth } from '@/hooks/useAuth';
+import { useGoogleAuth } from '@/hooks/useGoogleAuth';
+import LoginScreen from '@/app/login';
+
+// Mock dependencies
+jest.mock('expo-router', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+  Redirect: jest.fn().mockImplementation(({ href }) => <div>Redirecting to {href}</div>),
+}));
+
+jest.mock('expo-auth-session', () => ({
+  makeRedirectUri: jest.fn().mockReturnValue('exp://localhost:19000/--/auth/google'),
+  startAsync: jest.fn(),
+  maybeCompleteAuthSession: jest.fn(),
+}));
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('@/hooks/useGoogleAuth', () => ({
+  useGoogleAuth: jest.fn(),
+}));
+
+// Mock fetch
+global.fetch = jest.fn();
+
+// Test component that uses the auth hook
+const TestComponent = () => {
+  const { user, isAuthenticated, logout } = useAuth();
+  
+  return (
+    <div>
+      <div data-testid="auth-status">{isAuthenticated ? 'Authenticated' : 'Not authenticated'}</div>
+      {user && <div data-testid="user-email">{user.email}</div>}
+      <button data-testid="logout-button" onClick={logout}>Logout</button>
+    </div>
+  );
+};
+
+describe('Auth Context', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  
+  it('provides authentication context with initial unauthenticated state', async () => {
+    // Mock SecureStore to return null (no stored token)
+    SecureStore.getItemAsync.mockResolvedValue(null);
+    
+    let rendered;
+    await act(async () => {
+      rendered = render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+    });
+    
+    const { getByTestId } = rendered;
+    
+    // Check initial state
+    expect(getByTestId('auth-status').textContent).toBe('Not authenticated');
+    expect(SecureStore.getItemAsync).toHaveBeenCalledWith('auth_token');
+    expect(SecureStore.getItemAsync).toHaveBeenCalledWith('auth_user');
+  });
+  
+  it('loads authentication state from secure storage', async () => {
+    // Mock SecureStore to return token and user
+    const mockToken = 'test-token';
+    const mockUser = { id: '123', email: 'test@example.com', full_name: 'Test User', is_active: true, is_superuser: false };
+    
+    SecureStore.getItemAsync.mockImplementation((key) => {
+      if (key === 'auth_token') return Promise.resolve(mockToken);
+      if (key === 'auth_user') return Promise.resolve(JSON.stringify(mockUser));
+      return Promise.resolve(null);
+    });
+    
+    let rendered;
+    await act(async () => {
+      rendered = render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+    });
+    
+    const { getByTestId } = rendered;
+    
+    // Check authenticated state
+    expect(getByTestId('auth-status').textContent).toBe('Authenticated');
+    expect(getByTestId('user-email').textContent).toBe('test@example.com');
+  });
+  
+  it('handles logout correctly', async () => {
+    // Mock SecureStore to return token and user
+    const mockToken = 'test-token';
+    const mockUser = { id: '123', email: 'test@example.com', full_name: 'Test User', is_active: true, is_superuser: false };
+    
+    SecureStore.getItemAsync.mockImplementation((key) => {
+      if (key === 'auth_token') return Promise.resolve(mockToken);
+      if (key === 'auth_user') return Promise.resolve(JSON.stringify(mockUser));
+      return Promise.resolve(null);
+    });
+    
+    let rendered;
+    await act(async () => {
+      rendered = render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+    });
+    
+    const { getByTestId } = rendered;
+    
+    // Check authenticated state
+    expect(getByTestId('auth-status').textContent).toBe('Authenticated');
+    
+    // Trigger logout
+    await act(async () => {
+      fireEvent.press(getByTestId('logout-button'));
+    });
+    
+    // Check that SecureStore items were deleted
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth_token');
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('auth_user');
+    
+    // Check unauthenticated state
+    expect(getByTestId('auth-status').textContent).toBe('Not authenticated');
+  });
+});
+
+describe('Google Auth Hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  
+  it('handles successful Google sign-in', async () => {
+    // Mock the login function from useAuth
+    const mockLogin = jest.fn();
+    
+    // Mock the useAuth hook
+    jest.mock('@/hooks/useAuth', () => ({
+      useAuth: () => ({
+        login: mockLogin,
+      }),
+    }));
+    
+    // Mock successful AuthSession result
+    AuthSession.startAsync.mockResolvedValue({
+      type: 'success',
+      params: {
+        code: 'test-auth-code',
+      },
+      url: 'exp://localhost:19000/--/auth/google?code=test-auth-code',
+    });
+    
+    // Mock successful fetch response
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        access_token: 'test-access-token',
+        token_type: 'bearer',
+        user: {
+          id: '123',
+          email: 'test@example.com',
+          full_name: 'Test User',
+          is_active: true,
+          is_superuser: false,
+        },
+      }),
+    });
+    
+    // Create a mock implementation of useGoogleAuth
+    const mockGoogleSignIn = jest.fn().mockImplementation(async () => {
+      const result = await AuthSession.startAsync();
+      
+      if (result.type === 'success' && result.params.code) {
+        const response = await fetch(`http://localhost:8000/api/v1/login/auth/google/mobile?code=${result.params.code}`);
+        const data = await response.json();
+        await mockLogin(data.access_token, data.user);
+        return true;
+      }
+      
+      return false;
+    });
+    
+    useGoogleAuth.mockReturnValue({ googleSignIn: mockGoogleSignIn });
+    
+    // Render the login screen
+    const mockRouter = { replace: jest.fn() };
+    useRouter.mockReturnValue(mockRouter);
+    
+    let rendered;
+    await act(async () => {
+      rendered = render(<LoginScreen />);
+    });
+    
+    const { getByText } = rendered;
+    
+    // Trigger Google sign-in
+    await act(async () => {
+      fireEvent.press(getByText('Sign in with Google'));
+    });
+    
+    // Check that AuthSession.startAsync was called
+    expect(AuthSession.startAsync).toHaveBeenCalled();
+    
+    // Check that fetch was called with the correct URL
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/v1/login/auth/google/mobile?code=test-auth-code',
+      expect.any(Object)
+    );
+    
+    // Check that login was called with the correct arguments
+    expect(mockLogin).toHaveBeenCalledWith(
+      'test-access-token',
+      {
+        id: '123',
+        email: 'test@example.com',
+        full_name: 'Test User',
+        is_active: true,
+        is_superuser: false,
+      }
+    );
+    
+    // Check that router.replace was called to navigate to home
+    expect(mockRouter.replace).toHaveBeenCalledWith('/');
+  });
+  
+  it('handles Google sign-in error', async () => {
+    // Mock the login function from useAuth
+    const mockLogin = jest.fn();
+    
+    // Mock the useAuth hook
+    jest.mock('@/hooks/useAuth', () => ({
+      useAuth: () => ({
+        login: mockLogin,
+      }),
+    }));
+    
+    // Mock error AuthSession result
+    AuthSession.startAsync.mockResolvedValue({
+      type: 'error',
+      params: {
+        error: 'access_denied',
+      },
+    });
+    
+    // Create a mock implementation of useGoogleAuth that throws an error
+    const mockGoogleSignIn = jest.fn().mockImplementation(async () => {
+      const result = await AuthSession.startAsync();
+      
+      if (result.type === 'error' || result.params.error) {
+        throw new Error(result.params.error || 'Authentication failed');
+      }
+      
+      return false;
+    });
+    
+    useGoogleAuth.mockReturnValue({ googleSignIn: mockGoogleSignIn });
+    
+    // Render the login screen
+    const mockRouter = { replace: jest.fn() };
+    useRouter.mockReturnValue(mockRouter);
+    
+    let rendered;
+    await act(async () => {
+      rendered = render(<LoginScreen />);
+    });
+    
+    const { getByText, findByText } = rendered;
+    
+    // Trigger Google sign-in
+    await act(async () => {
+      fireEvent.press(getByText('Sign in with Google'));
+    });
+    
+    // Check that AuthSession.startAsync was called
+    expect(AuthSession.startAsync).toHaveBeenCalled();
+    
+    // Check that the error message is displayed
+    const errorMessage = await findByText('access_denied');
+    expect(errorMessage).toBeTruthy();
+    
+    // Check that login was not called
+    expect(mockLogin).not.toHaveBeenCalled();
+    
+    // Check that router.replace was not called
+    expect(mockRouter.replace).not.toHaveBeenCalled();
+  });
+});
+
+describe('Auth Guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  
+  it('redirects to login when not authenticated', async () => {
+    // Import the AuthGuard component
+    const { AuthGuard } = require('@/components/AuthGuard');
+    
+    // Mock useAuth to return not authenticated
+    jest.mock('@/hooks/useAuth', () => ({
+      useAuth: () => ({
+        isAuthenticated: false,
+        isLoading: false,
+      }),
+    }));
+    
+    // Mock usePathname to return a protected route
+    const usePathname = require('expo-router').usePathname;
+    usePathname.mockReturnValue('/protected');
+    
+    let rendered;
+    await act(async () => {
+      rendered = render(
+        <AuthGuard>
+          <div>Protected Content</div>
+        </AuthGuard>
+      );
+    });
+    
+    // Check that it redirects to login
+    expect(rendered.getByText('Redirecting to /login')).toBeTruthy();
+  });
+  
+  it('allows access to protected routes when authenticated', async () => {
+    // Import the AuthGuard component
+    const { AuthGuard } = require('@/components/AuthGuard');
+    
+    // Mock useAuth to return authenticated
+    jest.mock('@/hooks/useAuth', () => ({
+      useAuth: () => ({
+        isAuthenticated: true,
+        isLoading: false,
+      }),
+    }));
+    
+    // Mock usePathname to return a protected route
+    const usePathname = require('expo-router').usePathname;
+    usePathname.mockReturnValue('/protected');
+    
+    let rendered;
+    await act(async () => {
+      rendered = render(
+        <AuthGuard>
+          <div>Protected Content</div>
+        </AuthGuard>
+      );
+    });
+    
+    // Check that it renders the protected content
+    expect(rendered.getByText('Protected Content')).toBeTruthy();
+  });
+  
+  it('redirects to home when authenticated user tries to access login', async () => {
+    // Import the AuthGuard component
+    const { AuthGuard } = require('@/components/AuthGuard');
+    
+    // Mock useAuth to return authenticated
+    jest.mock('@/hooks/useAuth', () => ({
+      useAuth: () => ({
+        isAuthenticated: true,
+        isLoading: false,
+      }),
+    }));
+    
+    // Mock usePathname to return the login route
+    const usePathname = require('expo-router').usePathname;
+    usePathname.mockReturnValue('/login');
+    
+    let rendered;
+    await act(async () => {
+      rendered = render(
+        <AuthGuard>
+          <div>Login Screen</div>
+        </AuthGuard>
+      );
+    });
+    
+    // Check that it redirects to home
+    expect(rendered.getByText('Redirecting to /')).toBeTruthy();
+  });
+});

--- a/frontend-rn/tests/pkce-auth.test.tsx
+++ b/frontend-rn/tests/pkce-auth.test.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { useRouter } from 'expo-router';
+import * as AuthSession from 'expo-auth-session';
+import * as Crypto from 'expo-crypto';
+import * as SecureStore from 'expo-secure-store';
+import { AuthProvider, useAuth } from '@/hooks/useAuth';
+import { useGoogleAuth } from '@/hooks/useGoogleAuth';
+import LoginScreen from '@/app/login';
+
+// Mock dependencies
+jest.mock('expo-router', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+  Redirect: jest.fn().mockImplementation(({ href }) => <div>Redirecting to {href}</div>),
+}));
+
+jest.mock('expo-auth-session', () => ({
+  makeRedirectUri: jest.fn().mockReturnValue('exp://localhost:19000/--/auth/google'),
+  startAsync: jest.fn(),
+  maybeCompleteAuthSession: jest.fn(),
+  buildCodeVerifier: jest.fn().mockReturnValue('test_code_verifier'),
+  buildCodeChallenge: jest.fn().mockReturnValue('test_code_challenge'),
+  CodeChallengeMethod: { S256: 'S256' },
+}));
+
+jest.mock('expo-crypto', () => ({
+  getRandomBytesAsync: jest.fn().mockResolvedValue(new Uint8Array(32)),
+}));
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('@/hooks/useGoogleAuth', () => ({
+  useGoogleAuth: jest.fn(),
+}));
+
+// Mock fetch
+global.fetch = jest.fn();
+
+describe('PKCE Authentication Flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  
+  it('generates code verifier and challenge for PKCE flow', async () => {
+    // Mock the login function from useAuth
+    const mockLogin = jest.fn();
+    
+    // Mock the useAuth hook
+    jest.mock('@/hooks/useAuth', () => ({
+      useAuth: () => ({
+        login: mockLogin,
+      }),
+    }));
+    
+    // Mock successful AuthSession result
+    AuthSession.startAsync.mockResolvedValue({
+      type: 'success',
+      params: {
+        code: 'test-auth-code',
+      },
+      url: 'exp://localhost:19000/--/auth/google?code=test-auth-code',
+    });
+    
+    // Mock successful fetch response
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        access_token: 'test-access-token',
+        token_type: 'bearer',
+        user: {
+          id: '123',
+          email: 'test@example.com',
+          full_name: 'Test User',
+          is_active: true,
+          is_superuser: false,
+        },
+      }),
+    });
+    
+    // Create a mock implementation of useGoogleAuth
+    const mockGoogleSignIn = jest.fn().mockImplementation(async () => {
+      // Verify that code verifier and challenge are generated
+      expect(Crypto.getRandomBytesAsync).toHaveBeenCalledWith(32);
+      expect(AuthSession.buildCodeVerifier).toHaveBeenCalled();
+      expect(AuthSession.buildCodeChallenge).toHaveBeenCalledWith('test_code_verifier', 'S256');
+      
+      const result = await AuthSession.startAsync();
+      
+      if (result.type === 'success' && result.params.code) {
+        // Verify that code verifier is included in token exchange request
+        const response = await fetch(`http://localhost:8000/api/v1/login/auth/google/mobile?code=${result.params.code}&code_verifier=test_code_verifier`);
+        const data = await response.json();
+        await mockLogin(data.access_token, data.user);
+        return true;
+      }
+      
+      return false;
+    });
+    
+    useGoogleAuth.mockReturnValue({ googleSignIn: mockGoogleSignIn });
+    
+    // Render the login screen
+    const mockRouter = { replace: jest.fn() };
+    useRouter.mockReturnValue(mockRouter);
+    
+    let rendered;
+    await act(async () => {
+      rendered = render(<LoginScreen />);
+    });
+    
+    const { getByText } = rendered;
+    
+    // Trigger Google sign-in
+    await act(async () => {
+      fireEvent.press(getByText('Sign in with Google'));
+    });
+    
+    // Check that AuthSession.startAsync was called with URL containing code_challenge
+    expect(AuthSession.startAsync).toHaveBeenCalledWith({
+      authUrl: expect.stringContaining('code_challenge=test_code_challenge'),
+      returnUrl: 'exp://localhost:19000/--/auth/google',
+    });
+    
+    // Check that fetch was called with the correct URL including code_verifier
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('code_verifier=test_code_verifier'),
+      expect.any(Object)
+    );
+    
+    // Check that login was called with the correct arguments
+    expect(mockLogin).toHaveBeenCalledWith(
+      'test-access-token',
+      {
+        id: '123',
+        email: 'test@example.com',
+        full_name: 'Test User',
+        is_active: true,
+        is_superuser: false,
+      }
+    );
+    
+    // Check that router.replace was called to navigate to home
+    expect(mockRouter.replace).toHaveBeenCalledWith('/');
+  });
+  
+  it('handles errors in PKCE flow', async () => {
+    // Mock the login function from useAuth
+    const mockLogin = jest.fn();
+    
+    // Mock the useAuth hook
+    jest.mock('@/hooks/useAuth', () => ({
+      useAuth: () => ({
+        login: mockLogin,
+      }),
+    }));
+    
+    // Mock error in token exchange
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: () => Promise.resolve('Invalid code_verifier'),
+    });
+    
+    // Mock successful AuthSession result but failed token exchange
+    AuthSession.startAsync.mockResolvedValue({
+      type: 'success',
+      params: {
+        code: 'test-auth-code',
+      },
+      url: 'exp://localhost:19000/--/auth/google?code=test-auth-code',
+    });
+    
+    // Create a mock implementation of useGoogleAuth that throws an error
+    const mockGoogleSignIn = jest.fn().mockImplementation(async () => {
+      try {
+        const result = await AuthSession.startAsync();
+        
+        if (result.type === 'success' && result.params.code) {
+          const response = await fetch(`http://localhost:8000/api/v1/login/auth/google/mobile?code=${result.params.code}&code_verifier=test_code_verifier`);
+          
+          if (!response.ok) {
+            throw new Error(`Authentication failed: ${response.statusText}`);
+          }
+          
+          const data = await response.json();
+          await mockLogin(data.access_token, data.user);
+          return true;
+        }
+        
+        return false;
+      } catch (error) {
+        throw error;
+      }
+    });
+    
+    useGoogleAuth.mockReturnValue({ googleSignIn: mockGoogleSignIn });
+    
+    // Render the login screen
+    const mockRouter = { replace: jest.fn() };
+    useRouter.mockReturnValue(mockRouter);
+    
+    let rendered;
+    await act(async () => {
+      rendered = render(<LoginScreen />);
+    });
+    
+    const { getByText, findByText } = rendered;
+    
+    // Trigger Google sign-in
+    await act(async () => {
+      fireEvent.press(getByText('Sign in with Google'));
+    });
+    
+    // Check that the error message is displayed
+    const errorMessage = await findByText('Authentication failed: Bad Request');
+    expect(errorMessage).toBeTruthy();
+    
+    // Check that login was not called
+    expect(mockLogin).not.toHaveBeenCalled();
+    
+    // Check that router.replace was not called
+    expect(mockRouter.replace).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR reorganizes the frontend-rn route structure to implement protected routes according to the Expo Router documentation.

## Changes

1. Created two route groups:
   - `(auth)`: For public routes like sign-in
   - `(app)`: For protected routes that require authentication

2. Moved the existing tabs into the protected `(app)` group

3. Simplified the AuthGuard component to focus solely on checking authentication

4. Updated the root layout to properly handle the new route structure

This implementation follows the recommended pattern in the Expo Router documentation, using route groups to separate public routes from protected routes. It maintains the existing functionality while making the code more maintainable and following best practices.